### PR TITLE
Kernel instructions

### DIFF
--- a/PiCar-X/README.md
+++ b/PiCar-X/README.md
@@ -146,8 +146,8 @@ scripts/config --disable CONFIG_SYSTEM_TRUSTED_KEYS
 # This will take quite some time, with more cores you are faster
 make -j #NumberOfCores
 make bzImage
-make modules_install
-make install
+sudo make modules_install
+sudo make install
 
 sudo update-grub
 

--- a/PiCar-X/README.md
+++ b/PiCar-X/README.md
@@ -112,7 +112,7 @@ uname -r
 # POSSIBLE RESULT:
 On Ubuntu 20.04: 5.13.0-48-generic
 
-sudo apt-install wget unzip build-essential flex bison libssl-dev libelf-dev dwarves ncurses-dev zstd
+sudo apt-get install wget unzip build-essential flex bison libssl-dev libelf-dev dwarves ncurses-dev zstd
 
 wget https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.13.tar.gz
 


### PR DESCRIPTION
The instructions for the kernel build are mostly fine.
However, following them for Ubuntu 20.04 (ARM) revealed the following

1. Mistype in the installation command
2. `sudo` was required for `make modules_install` and `make install`

`make bzImage` did not work on my machine. However, the kernel build still succeeded and GPIO mockups seemed to work just fine.